### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/itwasnoteasy/f9c523e5-1cf8-40df-9086-63ea6929e9d1/46b2b731-1a5d-4d5c-9c56-51cd2e5fd287/_apis/work/boardbadge/3af668e5-9200-48ad-a1b1-7cf3dbf23552)](https://dev.azure.com/itwasnoteasy/f9c523e5-1cf8-40df-9086-63ea6929e9d1/_boards/board/t/46b2b731-1a5d-4d5c-9c56-51cd2e5fd287/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/itwasnoteasy/f9c523e5-1cf8-40df-9086-63ea6929e9d1/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.